### PR TITLE
Add offline Ollama-powered autonomous coding agent CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
-# kautuk
+# kautuk offline coding agent
+
+A local-first autonomous coding assistant that uses Ollama models to:
+
+- analyze natural language requests,
+- create a step-by-step implementation plan,
+- generate full project files,
+- run commands,
+- and attempt automatic fixes on failure.
+
+## Model strategy
+
+- `deepseek-coder` for code generation/fixing
+- `mistral` (or `llama3` for simple tasks) for planning
+- `gemma:2b` reserved for lightweight chat tasks
+
+## Install
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Prerequisites
+
+1. Install Ollama.
+2. Start Ollama server:
+
+```bash
+ollama serve
+```
+
+3. Pull models:
+
+```bash
+ollama pull deepseek-coder
+ollama pull mistral
+ollama pull llama3
+ollama pull gemma:2b
+```
+
+## Usage
+
+```bash
+kautuk-agent "Build a Flask todo API with tests" --workspace ./output_project
+```
+
+The agent prints JSON summary including selected models, generated files, and command execution results.
+
+## Output contract from code model
+
+The coder model is instructed to return blocks like:
+
+```xml
+<file path="app.py">
+# full file content
+</file>
+<run>
+python -m pytest -q
+</run>
+```
+
+This keeps file writes deterministic and enables automated execution + repair loops.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A local-first autonomous coding assistant for Ollama that simulates a multi-agen
 - Optional streaming progress updates (`--stream`) for incremental visibility
 - Interactive safety prompt for major file batches (`--interactive`)
 - Per-file change previews in CLI JSON (`file_changes`) to improve edit visibility
+- In interactive mode, CLI shows diff previews and requests approval before writing files
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # kautuk offline coding agent
 
-A local-first autonomous coding assistant that uses Ollama models to:
+A local-first autonomous coding assistant for Ollama that simulates a multi-agent workflow:
 
-- analyze natural language requests,
-- create a step-by-step implementation plan,
-- generate full project files,
-- run commands,
-- and attempt automatic fixes on failure.
+- **Planner Agent** (`mistral` / `llama3`) for step planning
+- **Coder Agent** (`deepseek-coder`) for full file generation
+- **Debugger Agent** (`deepseek-coder`) for auto-fix loops
+- **Reviewer Agent** (`mistral` / `llama3`) for quality improvements
 
-## Model strategy
+## Features
 
-- `deepseek-coder` for code generation/fixing
-- `mistral` (or `llama3` for simple tasks) for planning
-- `gemma:2b` reserved for lightweight chat tasks
+- Structured generation contract with `<plan>`, `<files>`, and `<commands>` blocks
+- Safe local tools API (`read_file`, `write_file`, `list_files`, `run_command`, `install_package`)
+- Persistent memory (`conversation_history`, `project_files`, `previous_errors`)
+- Execution loop with automatic debugging up to 5 iterations
 
 ## Install
 
@@ -24,16 +24,8 @@ pip install -e .
 
 ## Prerequisites
 
-1. Install Ollama.
-2. Start Ollama server:
-
 ```bash
 ollama serve
-```
-
-3. Pull models:
-
-```bash
 ollama pull deepseek-coder
 ollama pull mistral
 ollama pull llama3
@@ -43,22 +35,32 @@ ollama pull gemma:2b
 ## Usage
 
 ```bash
-kautuk-agent "Build a Flask todo API with tests" --workspace ./output_project
+kautuk-agent "Build a FastAPI todo app with tests" --workspace ./output_project --max-iters 5
 ```
 
-The agent prints JSON summary including selected models, generated files, and command execution results.
+Optional memory file:
 
-## Output contract from code model
+```bash
+kautuk-agent "Improve existing project" --workspace ./output_project --memory-file ./agent-memory.json
+```
 
-The coder model is instructed to return blocks like:
+## Model output format
 
 ```xml
+<plan>
+1. Analyze...
+2. Implement...
+</plan>
+
+<files>
 <file path="app.py">
-# full file content
+# full code
 </file>
-<run>
+</files>
+
+<commands>
 python -m pytest -q
-</run>
+</commands>
 ```
 
-This keeps file writes deterministic and enables automated execution + repair loops.
+The CLI prints JSON with selected models, planner output, review notes, generated files, iteration logs, and memory path.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A local-first autonomous coding assistant for Ollama that simulates a multi-agen
 - Safe local tools API (`read_file`, `write_file`, `list_files`, `run_command`, `install_package`)
 - Persistent memory (`conversation_history`, `project_files`, `previous_errors`)
 - Execution loop with automatic debugging up to 5 iterations and command timeout protection
+- Retrieval-aware file selection so prompts include only relevant codebase context
+- Optional streaming progress updates (`--stream`) for incremental visibility
 
 ## Install
 
@@ -35,7 +37,7 @@ ollama pull gemma:2b
 ## Usage
 
 ```bash
-kautuk-agent "Build a FastAPI todo app with tests" --workspace ./output_project --max-iters 5
+kautuk-agent "Build a FastAPI todo app with tests" --workspace ./output_project --max-iters 5 --stream
 ```
 
 Optional memory file:

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ A local-first autonomous coding assistant for Ollama that simulates a multi-agen
 
 ## Features
 
-- Structured generation contract with `<plan>`, `<reflection>`, `<files>`, `<commands>`, and `<iteration_log>` blocks
+- Structured generation contract with `<plan>`, `<reflection>`, `<codebase_analysis>`, `<files>`, `<commands>`, and `<iteration_log>` blocks
 - Safe local tools API (`read_file`, `write_file`, `list_files`, `run_command`, `install_package`)
 - Persistent memory (`conversation_history`, `project_files`, `previous_errors`)
-- Execution loop with automatic debugging up to 5 iterations
+- Execution loop with automatic debugging up to 5 iterations and command timeout protection
 
 ## Install
 
@@ -55,6 +55,10 @@ kautuk-agent "Improve existing project" --workspace ./output_project --memory-fi
 <reflection>
 Plan quality is acceptable; improve test coverage.
 </reflection>
+
+<codebase_analysis>
+Current project contains CLI, parser, and tests modules.
+</codebase_analysis>
 
 <files>
 <file path="app.py">

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A local-first autonomous coding assistant for Ollama that simulates a multi-agen
 
 ## Features
 
-- Structured generation contract with `<plan>`, `<files>`, and `<commands>` blocks
+- Structured generation contract with `<plan>`, `<reflection>`, `<files>`, `<commands>`, and `<iteration_log>` blocks
 - Safe local tools API (`read_file`, `write_file`, `list_files`, `run_command`, `install_package`)
 - Persistent memory (`conversation_history`, `project_files`, `previous_errors`)
 - Execution loop with automatic debugging up to 5 iterations
@@ -52,6 +52,10 @@ kautuk-agent "Improve existing project" --workspace ./output_project --memory-fi
 2. Implement...
 </plan>
 
+<reflection>
+Plan quality is acceptable; improve test coverage.
+</reflection>
+
 <files>
 <file path="app.py">
 # full code
@@ -61,6 +65,10 @@ kautuk-agent "Improve existing project" --workspace ./output_project --memory-fi
 <commands>
 python -m pytest -q
 </commands>
+
+<iteration_log>
+Generated initial project scaffold and tests.
+</iteration_log>
 ```
 
 The CLI prints JSON with selected models, planner output, review notes, generated files, iteration logs, and memory path.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A local-first autonomous coding assistant for Ollama that simulates a multi-agen
 - Interactive safety prompt for major file batches (`--interactive`)
 - Per-file change previews in CLI JSON (`file_changes`) to improve edit visibility
 - In interactive mode, CLI shows diff previews and requests approval before writing files
+- Proposal mode (`--propose-only`) validates and previews diffs without modifying files
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ A local-first autonomous coding assistant for Ollama that simulates a multi-agen
 - Execution loop with automatic debugging up to 5 iterations and command timeout protection
 - Retrieval-aware file selection so prompts include only relevant codebase context
 - Optional streaming progress updates (`--stream`) for incremental visibility
+- Interactive safety prompt for major file batches (`--interactive`)
+- Per-file change previews in CLI JSON (`file_changes`) to improve edit visibility
 
 ## Install
 
@@ -38,7 +40,7 @@ ollama pull gemma:2b
 ## Usage
 
 ```bash
-kautuk-agent "Build a FastAPI todo app with tests" --workspace ./output_project --max-iters 5 --stream
+kautuk-agent "Build a FastAPI todo app with tests" --workspace ./output_project --max-iters 5 --stream --interactive
 ```
 
 Optional memory file:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A local-first autonomous coding assistant for Ollama that simulates a multi-agen
 
 - Structured generation contract with `<plan>`, `<reflection>`, `<codebase_analysis>`, `<files>`, `<commands>`, and `<iteration_log>` blocks
 - Safe local tools API (`read_file`, `write_file`, `list_files`, `run_command`, `install_package`)
+- Destructive command guardrails (blocks risky commands unless explicitly overridden)
 - Persistent memory (`conversation_history`, `project_files`, `previous_errors`)
 - Execution loop with automatic debugging up to 5 iterations and command timeout protection
 - Retrieval-aware file selection so prompts include only relevant codebase context
@@ -49,6 +50,10 @@ kautuk-agent "Improve existing project" --workspace ./output_project --memory-fi
 ## Model output format
 
 ```xml
+<spec>
+Requirements, constraints, and architecture summary.
+</spec>
+
 <plan>
 1. Analyze...
 2. Implement...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "kautuk-offline-agent"
+version = "0.1.0"
+description = "Autonomous offline coding assistant powered by local Ollama models"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{ name = "kautuk" }]
+
+[project.scripts]
+kautuk-agent = "kautuk_offline_agent.cli:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/src/kautuk_offline_agent/__init__.py
+++ b/src/kautuk_offline_agent/__init__.py
@@ -1,0 +1,5 @@
+"""Offline autonomous coding assistant package."""
+
+from .agent import OfflineCodingAgent
+
+__all__ = ["OfflineCodingAgent"]

--- a/src/kautuk_offline_agent/__init__.py
+++ b/src/kautuk_offline_agent/__init__.py
@@ -1,5 +1,7 @@
 """Offline autonomous coding assistant package."""
 
 from .agent import OfflineCodingAgent
+from .memory import SessionMemory
+from .tools import LocalTooling
 
-__all__ = ["OfflineCodingAgent"]
+__all__ = ["OfflineCodingAgent", "SessionMemory", "LocalTooling"]

--- a/src/kautuk_offline_agent/agent.py
+++ b/src/kautuk_offline_agent/agent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from difflib import unified_diff
 from pathlib import Path
 from typing import Callable
 
@@ -49,6 +50,13 @@ class IterationLog:
     output: str
 
 
+@dataclass
+class FileChange:
+    path: str
+    status: str
+    diff_preview: str
+
+
 class OfflineCodingAgent:
     def __init__(self, client: OllamaClient | None = None) -> None:
         self.client = client or OllamaClient()
@@ -60,6 +68,8 @@ class OfflineCodingAgent:
         max_iters: int = 5,
         memory_file: Path | None = None,
         progress_callback: Callable[[str], None] | None = None,
+        approve_major_changes: bool = False,
+        major_change_threshold: int = 10,
     ) -> dict:
         workspace = workspace.resolve()
         workspace.mkdir(parents=True, exist_ok=True)
@@ -82,7 +92,12 @@ class OfflineCodingAgent:
         plan_reflection = self._reflect(models, f"Reflect on this plan and improve it:\n\n{planner_output}")
         self._emit_progress(progress_callback, "Reflected on plan quality.")
         coded = self._code(task, technical_spec, planner_output, models, memory, codebase_snapshot)
-        parsed = self._materialize(coded, tooling)
+        parsed, file_changes = self._materialize(
+            coded,
+            tooling,
+            approve_major_changes=approve_major_changes,
+            major_change_threshold=major_change_threshold,
+        )
         self._emit_progress(progress_callback, "Materialized generated files.")
 
         iteration_logs: list[IterationLog] = []
@@ -119,7 +134,8 @@ class OfflineCodingAgent:
                 f"Command: {failed.command}\nOutput:\n{failed.merged_output}",
             )
             memory.conversation_history.append(fix_reflection)
-            current_output = self._materialize(debug_response, tooling)
+            current_output, debug_changes = self._materialize(debug_response, tooling)
+            file_changes.extend(debug_changes)
             self._emit_progress(progress_callback, f"Iteration {idx} failed; applied automated debug fix.")
 
         review_notes = self._review(task, planner_output, models, memory, tooling.list_files("."))
@@ -138,6 +154,7 @@ class OfflineCodingAgent:
             "codebase_analysis": parsed.codebase_analysis,
             "review_notes": review_notes,
             "written_files": [generated.path for generated in parsed.files],
+            "file_changes": [change.__dict__ for change in file_changes],
             "relevant_files": relevant_files,
             "iterations": iteration_logs,
             "model_iteration_log": parsed.iteration_log,
@@ -218,13 +235,42 @@ class OfflineCodingAgent:
         return self.client.generate(models.planner, prompt, system=REVIEWER_SYSTEM)
 
     @staticmethod
-    def _materialize(raw: str, tooling: LocalTooling) -> StructuredOutput:
+    def _materialize(
+        raw: str,
+        tooling: LocalTooling,
+        approve_major_changes: bool = True,
+        major_change_threshold: int = 10,
+    ) -> tuple[StructuredOutput, list[FileChange]]:
         parsed = parse_structured_output(raw)
         if not parsed.files:
             raise ValueError("Model response did not include any <file> blocks.")
+        if len(parsed.files) > major_change_threshold and not approve_major_changes:
+            raise ValueError(
+                f"Major change detected ({len(parsed.files)} files). "
+                "Set approve_major_changes=True to continue."
+            )
+        changes: list[FileChange] = []
         for generated in parsed.files:
+            try:
+                existing = tooling.read_file(generated.path)
+                status = "modified"
+            except FileNotFoundError:
+                existing = ""
+                status = "created"
             tooling.write_file(generated.path, generated.content)
-        return parsed
+            diff_lines = list(
+                unified_diff(
+                    existing.splitlines(),
+                    generated.content.splitlines(),
+                    fromfile=f"a/{generated.path}",
+                    tofile=f"b/{generated.path}",
+                    lineterm="",
+                    n=2,
+                )
+            )
+            preview = "\n".join(diff_lines[:40])
+            changes.append(FileChange(path=generated.path, status=status, diff_preview=preview))
+        return parsed, changes
 
     def _reflect(self, models: ModelSelection, content: str) -> str:
         return self.client.generate(models.planner, content, system=REFLECTION_SYSTEM)

--- a/src/kautuk_offline_agent/agent.py
+++ b/src/kautuk_offline_agent/agent.py
@@ -12,6 +12,9 @@ from .workspace import StructuredOutput, parse_structured_output
 
 PLANNER_SYSTEM = """You are Planner Agent (mistral/llama3 role). Build concise step-by-step plans."""
 CODER_SYSTEM = """You are Coder Agent (deepseek-coder role). Return exactly:
+<spec>
+...
+</spec>
 <plan>
 ...
 </plan>
@@ -72,11 +75,13 @@ class OfflineCodingAgent:
         relevant_files = self._select_relevant_files(task, all_files)
         codebase_snapshot = self._describe_codebase(relevant_files)
         self._emit_progress(progress_callback, "Analyzed codebase and selected relevant files.")
+        technical_spec = self._build_spec(task, models, codebase_snapshot)
+        self._emit_progress(progress_callback, "Built technical specification.")
         planner_output = self._plan(task, models, memory)
         self._emit_progress(progress_callback, "Generated plan.")
         plan_reflection = self._reflect(models, f"Reflect on this plan and improve it:\n\n{planner_output}")
         self._emit_progress(progress_callback, "Reflected on plan quality.")
-        coded = self._code(task, planner_output, models, memory, codebase_snapshot)
+        coded = self._code(task, technical_spec, planner_output, models, memory, codebase_snapshot)
         parsed = self._materialize(coded, tooling)
         self._emit_progress(progress_callback, "Materialized generated files.")
 
@@ -126,6 +131,8 @@ class OfflineCodingAgent:
         return {
             "models": models,
             "planner_output": planner_output,
+            "technical_spec": technical_spec,
+            "model_spec": parsed.spec,
             "plan_reflection": plan_reflection,
             "generation_reflection": parsed.reflection,
             "codebase_analysis": parsed.codebase_analysis,
@@ -145,9 +152,18 @@ class OfflineCodingAgent:
         )
         return self.client.generate(models.planner, prompt, system=PLANNER_SYSTEM)
 
+    def _build_spec(self, task: str, models: ModelSelection, codebase_snapshot: str) -> str:
+        prompt = (
+            "Create a concise technical specification with requirements, constraints, and architecture.\n\n"
+            f"Task:\n{task}\n\n"
+            f"Relevant codebase context:\n{codebase_snapshot}\n"
+        )
+        return self.client.generate(models.planner, prompt, system=PLANNER_SYSTEM)
+
     def _code(
         self,
         task: str,
+        technical_spec: str,
         plan: str,
         models: ModelSelection,
         memory: SessionMemory,
@@ -155,6 +171,7 @@ class OfflineCodingAgent:
     ) -> str:
         prompt = (
             f"Task:\n{task}\n\n"
+            f"Technical specification:\n{technical_spec}\n\n"
             f"Planner Notes:\n{plan}\n\n"
             f"Known project files:\n{memory.project_files}\n\n"
             f"Codebase snapshot:\n{codebase_snapshot}\n\n"

--- a/src/kautuk_offline_agent/agent.py
+++ b/src/kautuk_offline_agent/agent.py
@@ -14,6 +14,9 @@ CODER_SYSTEM = """You are Coder Agent (deepseek-coder role). Return exactly:
 <plan>
 ...
 </plan>
+<reflection>
+...
+</reflection>
 <files>
 <file path=\"relative/path\">\nfull content\n</file>
 </files>
@@ -21,10 +24,14 @@ CODER_SYSTEM = """You are Coder Agent (deepseek-coder role). Return exactly:
 command one
 command two
 </commands>
+<iteration_log>
+short generation summary
+</iteration_log>
 Rules: produce full files, include comments, error handling, and modular architecture.
 """
 DEBUGGER_SYSTEM = """You are Debugger Agent (deepseek-coder role). Fix failing code using error logs. Return same structured format."""
 REVIEWER_SYSTEM = """You are Reviewer Agent (mistral/llama3 role). Suggest quality/scalability improvements in short bullets."""
+REFLECTION_SYSTEM = """You are Reflection Agent. Evaluate output quality, identify weaknesses, and suggest immediate improvements."""
 
 
 @dataclass
@@ -56,6 +63,7 @@ class OfflineCodingAgent:
 
         models = select_models(task)
         planner_output = self._plan(task, models, memory)
+        plan_reflection = self._reflect(models, f"Reflect on this plan and improve it:\n\n{planner_output}")
         coded = self._code(task, planner_output, models, memory)
         parsed = self._materialize(coded, tooling)
 
@@ -86,6 +94,12 @@ class OfflineCodingAgent:
                 break
 
             debug_response = self._debug(task, planner_output, models, memory, failed)
+            fix_reflection = self._reflect(
+                models,
+                "Classify the error type (syntax/runtime/dependency/logic) and evaluate the fix quality.\n\n"
+                f"Command: {failed.command}\nOutput:\n{failed.merged_output}",
+            )
+            memory.conversation_history.append(fix_reflection)
             current_output = self._materialize(debug_response, tooling)
 
         review_notes = self._review(task, planner_output, models, memory, tooling.list_files("."))
@@ -96,9 +110,12 @@ class OfflineCodingAgent:
         return {
             "models": models,
             "planner_output": planner_output,
+            "plan_reflection": plan_reflection,
+            "generation_reflection": parsed.reflection,
             "review_notes": review_notes,
             "written_files": [generated.path for generated in parsed.files],
             "iterations": iteration_logs,
+            "model_iteration_log": parsed.iteration_log,
             "memory_file": str(memory_path),
         }
 
@@ -115,7 +132,8 @@ class OfflineCodingAgent:
             f"Task:\n{task}\n\n"
             f"Planner Notes:\n{plan}\n\n"
             f"Known project files:\n{memory.project_files}\n\n"
-            "Generate implementation with required structured format."
+            "Generate exactly two implementation approaches, compare them briefly, then choose one and implement it.\n"
+            "Use required structured format."
         )
         return self.client.generate(models.coder, prompt, system=CODER_SYSTEM)
 
@@ -132,6 +150,7 @@ class OfflineCodingAgent:
             f"Plan:\n{plan}\n\n"
             f"Failed command:\n{failed.command}\n\n"
             f"Error:\n{failed.merged_output}\n\n"
+            f"Error type guess:\n{self._classify_error(failed.merged_output)}\n\n"
             f"Recent errors:\n{memory.previous_errors[-5:]}\n\n"
             "Fix all root causes and return full files + commands."
         )
@@ -162,3 +181,17 @@ class OfflineCodingAgent:
         for generated in parsed.files:
             tooling.write_file(generated.path, generated.content)
         return parsed
+
+    def _reflect(self, models: ModelSelection, content: str) -> str:
+        return self.client.generate(models.planner, content, system=REFLECTION_SYSTEM)
+
+    @staticmethod
+    def _classify_error(error_output: str) -> str:
+        lowered = error_output.lower()
+        if "syntaxerror" in lowered or "invalid syntax" in lowered:
+            return "syntax"
+        if "no module named" in lowered or "not found" in lowered:
+            return "dependency"
+        if "traceback (most recent call last)" in lowered or "exception" in lowered:
+            return "runtime"
+        return "logic"

--- a/src/kautuk_offline_agent/agent.py
+++ b/src/kautuk_offline_agent/agent.py
@@ -17,6 +17,9 @@ CODER_SYSTEM = """You are Coder Agent (deepseek-coder role). Return exactly:
 <reflection>
 ...
 </reflection>
+<codebase_analysis>
+...
+</codebase_analysis>
 <files>
 <file path=\"relative/path\">\nfull content\n</file>
 </files>
@@ -60,11 +63,13 @@ class OfflineCodingAgent:
         memory_path = memory_file or workspace / ".agent_memory.json"
         memory = SessionMemory.load(memory_path)
         memory.conversation_history.append(task)
+        memory.compact()
 
         models = select_models(task)
+        codebase_snapshot = self._describe_codebase(tooling.list_files("."))
         planner_output = self._plan(task, models, memory)
         plan_reflection = self._reflect(models, f"Reflect on this plan and improve it:\n\n{planner_output}")
-        coded = self._code(task, planner_output, models, memory)
+        coded = self._code(task, planner_output, models, memory, codebase_snapshot)
         parsed = self._materialize(coded, tooling)
 
         iteration_logs: list[IterationLog] = []
@@ -112,6 +117,7 @@ class OfflineCodingAgent:
             "planner_output": planner_output,
             "plan_reflection": plan_reflection,
             "generation_reflection": parsed.reflection,
+            "codebase_analysis": parsed.codebase_analysis,
             "review_notes": review_notes,
             "written_files": [generated.path for generated in parsed.files],
             "iterations": iteration_logs,
@@ -127,11 +133,20 @@ class OfflineCodingAgent:
         )
         return self.client.generate(models.planner, prompt, system=PLANNER_SYSTEM)
 
-    def _code(self, task: str, plan: str, models: ModelSelection, memory: SessionMemory) -> str:
+    def _code(
+        self,
+        task: str,
+        plan: str,
+        models: ModelSelection,
+        memory: SessionMemory,
+        codebase_snapshot: str,
+    ) -> str:
         prompt = (
             f"Task:\n{task}\n\n"
             f"Planner Notes:\n{plan}\n\n"
             f"Known project files:\n{memory.project_files}\n\n"
+            f"Codebase snapshot:\n{codebase_snapshot}\n\n"
+            f"Conversation summary:\n{memory.conversation_summary}\n\n"
             "Generate exactly two implementation approaches, compare them briefly, then choose one and implement it.\n"
             "Use required structured format."
         )
@@ -195,3 +210,11 @@ class OfflineCodingAgent:
         if "traceback (most recent call last)" in lowered or "exception" in lowered:
             return "runtime"
         return "logic"
+
+    @staticmethod
+    def _describe_codebase(files: list[str], max_files: int = 40) -> str:
+        if not files:
+            return "No files detected."
+        sample = files[:max_files]
+        suffix = "" if len(files) <= max_files else f"\n...and {len(files) - max_files} more files."
+        return "\n".join(sample) + suffix

--- a/src/kautuk_offline_agent/agent.py
+++ b/src/kautuk_offline_agent/agent.py
@@ -1,35 +1,37 @@
 from __future__ import annotations
 
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from .memory import SessionMemory
 from .models import ModelSelection, select_models
 from .ollama_client import OllamaClient
-from .workspace import parse_model_output, write_artifacts
+from .tools import CommandResult, LocalTooling
+from .workspace import StructuredOutput, parse_structured_output
 
-PLANNER_SYSTEM = """You are a senior software architect. Create concise step-by-step implementation plans."""
-
-CODER_SYSTEM = """You are an autonomous coding agent. Output only this XML-like format:
-<analysis>short explanation</analysis>
-<file path=\"relative/path\">\n...full file content...\n</file>
-<file path=\"another/file\">\n...\n</file>
-<run>\ncommand to run\n</run>
-Rules:
-- Always provide complete files, never partial snippets.
-- Use clean modular production-ready code.
-- Include error handling and comments.
-- Emit at least one <file> block.
-- Include <run> blocks only for safe local commands.
+PLANNER_SYSTEM = """You are Planner Agent (mistral/llama3 role). Build concise step-by-step plans."""
+CODER_SYSTEM = """You are Coder Agent (deepseek-coder role). Return exactly:
+<plan>
+...
+</plan>
+<files>
+<file path=\"relative/path\">\nfull content\n</file>
+</files>
+<commands>
+command one
+command two
+</commands>
+Rules: produce full files, include comments, error handling, and modular architecture.
 """
-
-FIXER_SYSTEM = """You are a debugging assistant. Given command errors, return replacement full files and test commands using the same XML format as requested."""
+DEBUGGER_SYSTEM = """You are Debugger Agent (deepseek-coder role). Fix failing code using error logs. Return same structured format."""
+REVIEWER_SYSTEM = """You are Reviewer Agent (mistral/llama3 role). Suggest quality/scalability improvements in short bullets."""
 
 
 @dataclass
-class IterationResult:
-    ok: bool
+class IterationLog:
+    iteration: int
     command: str
+    ok: bool
     output: str
 
 
@@ -37,80 +39,126 @@ class OfflineCodingAgent:
     def __init__(self, client: OllamaClient | None = None) -> None:
         self.client = client or OllamaClient()
 
-    def run(self, task: str, workspace: Path, max_iters: int = 3) -> dict:
+    def run(
+        self,
+        task: str,
+        workspace: Path,
+        max_iters: int = 5,
+        memory_file: Path | None = None,
+    ) -> dict:
         workspace = workspace.resolve()
         workspace.mkdir(parents=True, exist_ok=True)
+        tooling = LocalTooling(workspace)
+
+        memory_path = memory_file or workspace / ".agent_memory.json"
+        memory = SessionMemory.load(memory_path)
+        memory.conversation_history.append(task)
 
         models = select_models(task)
-        plan = self._plan(task, models)
-        draft = self._implement(task, plan, models)
+        planner_output = self._plan(task, models, memory)
+        coded = self._code(task, planner_output, models, memory)
+        parsed = self._materialize(coded, tooling)
 
-        parsed = parse_model_output(draft, workspace)
-        written_paths = write_artifacts(parsed.artifacts)
+        iteration_logs: list[IterationLog] = []
+        current_output = parsed
 
-        run_results: list[IterationResult] = []
-        for command in parsed.run_commands:
-            result = self._run_command(command, workspace)
-            run_results.append(result)
-            if not result.ok:
-                for _ in range(max_iters):
-                    fix = self._fix(task, plan, models, command, result.output)
-                    fix_parsed = parse_model_output(fix, workspace)
-                    write_artifacts(fix_parsed.artifacts)
-                    rerun = self._run_command(command, workspace)
-                    run_results.append(rerun)
-                    if rerun.ok:
-                        break
+        for idx in range(1, max_iters + 1):
+            if not current_output.commands:
                 break
+
+            failed: CommandResult | None = None
+            for command in current_output.commands:
+                result = tooling.run_command(command)
+                iteration_logs.append(
+                    IterationLog(
+                        iteration=idx,
+                        command=command,
+                        ok=result.ok,
+                        output=result.merged_output,
+                    )
+                )
+                if not result.ok:
+                    failed = result
+                    memory.previous_errors.append(result.merged_output)
+                    break
+
+            if failed is None:
+                break
+
+            debug_response = self._debug(task, planner_output, models, memory, failed)
+            current_output = self._materialize(debug_response, tooling)
+
+        review_notes = self._review(task, planner_output, models, memory, tooling.list_files("."))
+
+        memory.project_files = tooling.list_files(".")
+        memory.save(memory_path)
 
         return {
             "models": models,
-            "plan": plan,
-            "written_files": [str(path.relative_to(workspace)) for path in written_paths],
-            "run_results": run_results,
+            "planner_output": planner_output,
+            "review_notes": review_notes,
+            "written_files": [generated.path for generated in parsed.files],
+            "iterations": iteration_logs,
+            "memory_file": str(memory_path),
         }
 
-    def _plan(self, task: str, models: ModelSelection) -> str:
+    def _plan(self, task: str, models: ModelSelection, memory: SessionMemory) -> str:
         prompt = (
-            "Create a practical implementation plan for this coding request. "
-            "Keep it under 10 steps.\n\n"
-            f"Request:\n{task}\n"
+            "Analyze request and propose a step-by-step plan under 10 steps.\n"
+            f"Task:\n{task}\n\n"
+            f"Previous errors:\n{memory.previous_errors[-3:]}\n"
         )
         return self.client.generate(models.planner, prompt, system=PLANNER_SYSTEM)
 
-    def _implement(self, task: str, plan: str, models: ModelSelection) -> str:
+    def _code(self, task: str, plan: str, models: ModelSelection, memory: SessionMemory) -> str:
         prompt = (
             f"Task:\n{task}\n\n"
-            f"Plan:\n{plan}\n\n"
-            "Now implement. Return full files in the requested XML format."
+            f"Planner Notes:\n{plan}\n\n"
+            f"Known project files:\n{memory.project_files}\n\n"
+            "Generate implementation with required structured format."
         )
         return self.client.generate(models.coder, prompt, system=CODER_SYSTEM)
 
-    def _fix(
+    def _debug(
         self,
         task: str,
         plan: str,
         models: ModelSelection,
-        failed_command: str,
-        error_output: str,
+        memory: SessionMemory,
+        failed: CommandResult,
     ) -> str:
         prompt = (
             f"Task:\n{task}\n\n"
             f"Plan:\n{plan}\n\n"
-            f"Failed command:\n{failed_command}\n\n"
-            f"Error output:\n{error_output}\n\n"
-            "Provide fixed full files and optionally improved run commands in XML format."
+            f"Failed command:\n{failed.command}\n\n"
+            f"Error:\n{failed.merged_output}\n\n"
+            f"Recent errors:\n{memory.previous_errors[-5:]}\n\n"
+            "Fix all root causes and return full files + commands."
         )
-        return self.client.generate(models.coder, prompt, system=FIXER_SYSTEM)
+        return self.client.generate(models.coder, prompt, system=DEBUGGER_SYSTEM)
+
+    def _review(
+        self,
+        task: str,
+        plan: str,
+        models: ModelSelection,
+        memory: SessionMemory,
+        files: list[str],
+    ) -> str:
+        prompt = (
+            f"Task:\n{task}\n\n"
+            f"Plan:\n{plan}\n\n"
+            f"Files generated:\n{files}\n\n"
+            f"Memory errors:\n{memory.previous_errors[-3:]}\n\n"
+            "Provide concise quality review and next improvements."
+        )
+        return self.client.generate(models.planner, prompt, system=REVIEWER_SYSTEM)
 
     @staticmethod
-    def _run_command(command: str, cwd: Path) -> IterationResult:
-        completed = subprocess.run(
-            command,
-            cwd=cwd,
-            shell=True,
-            text=True,
-            capture_output=True,
-        )
-        output = (completed.stdout + "\n" + completed.stderr).strip()
-        return IterationResult(ok=completed.returncode == 0, command=command, output=output)
+    def _materialize(raw: str, tooling: LocalTooling) -> StructuredOutput:
+        parsed = parse_structured_output(raw)
+        if not parsed.files:
+            raise ValueError("Model response did not include any <file> blocks.")
+        for generated in parsed.files:
+            tooling.write_file(generated.path, generated.content)
+        return parsed

--- a/src/kautuk_offline_agent/agent.py
+++ b/src/kautuk_offline_agent/agent.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from .models import ModelSelection, select_models
+from .ollama_client import OllamaClient
+from .workspace import parse_model_output, write_artifacts
+
+PLANNER_SYSTEM = """You are a senior software architect. Create concise step-by-step implementation plans."""
+
+CODER_SYSTEM = """You are an autonomous coding agent. Output only this XML-like format:
+<analysis>short explanation</analysis>
+<file path=\"relative/path\">\n...full file content...\n</file>
+<file path=\"another/file\">\n...\n</file>
+<run>\ncommand to run\n</run>
+Rules:
+- Always provide complete files, never partial snippets.
+- Use clean modular production-ready code.
+- Include error handling and comments.
+- Emit at least one <file> block.
+- Include <run> blocks only for safe local commands.
+"""
+
+FIXER_SYSTEM = """You are a debugging assistant. Given command errors, return replacement full files and test commands using the same XML format as requested."""
+
+
+@dataclass
+class IterationResult:
+    ok: bool
+    command: str
+    output: str
+
+
+class OfflineCodingAgent:
+    def __init__(self, client: OllamaClient | None = None) -> None:
+        self.client = client or OllamaClient()
+
+    def run(self, task: str, workspace: Path, max_iters: int = 3) -> dict:
+        workspace = workspace.resolve()
+        workspace.mkdir(parents=True, exist_ok=True)
+
+        models = select_models(task)
+        plan = self._plan(task, models)
+        draft = self._implement(task, plan, models)
+
+        parsed = parse_model_output(draft, workspace)
+        written_paths = write_artifacts(parsed.artifacts)
+
+        run_results: list[IterationResult] = []
+        for command in parsed.run_commands:
+            result = self._run_command(command, workspace)
+            run_results.append(result)
+            if not result.ok:
+                for _ in range(max_iters):
+                    fix = self._fix(task, plan, models, command, result.output)
+                    fix_parsed = parse_model_output(fix, workspace)
+                    write_artifacts(fix_parsed.artifacts)
+                    rerun = self._run_command(command, workspace)
+                    run_results.append(rerun)
+                    if rerun.ok:
+                        break
+                break
+
+        return {
+            "models": models,
+            "plan": plan,
+            "written_files": [str(path.relative_to(workspace)) for path in written_paths],
+            "run_results": run_results,
+        }
+
+    def _plan(self, task: str, models: ModelSelection) -> str:
+        prompt = (
+            "Create a practical implementation plan for this coding request. "
+            "Keep it under 10 steps.\n\n"
+            f"Request:\n{task}\n"
+        )
+        return self.client.generate(models.planner, prompt, system=PLANNER_SYSTEM)
+
+    def _implement(self, task: str, plan: str, models: ModelSelection) -> str:
+        prompt = (
+            f"Task:\n{task}\n\n"
+            f"Plan:\n{plan}\n\n"
+            "Now implement. Return full files in the requested XML format."
+        )
+        return self.client.generate(models.coder, prompt, system=CODER_SYSTEM)
+
+    def _fix(
+        self,
+        task: str,
+        plan: str,
+        models: ModelSelection,
+        failed_command: str,
+        error_output: str,
+    ) -> str:
+        prompt = (
+            f"Task:\n{task}\n\n"
+            f"Plan:\n{plan}\n\n"
+            f"Failed command:\n{failed_command}\n\n"
+            f"Error output:\n{error_output}\n\n"
+            "Provide fixed full files and optionally improved run commands in XML format."
+        )
+        return self.client.generate(models.coder, prompt, system=FIXER_SYSTEM)
+
+    @staticmethod
+    def _run_command(command: str, cwd: Path) -> IterationResult:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            shell=True,
+            text=True,
+            capture_output=True,
+        )
+        output = (completed.stdout + "\n" + completed.stderr).strip()
+        return IterationResult(ok=completed.returncode == 0, command=command, output=output)

--- a/src/kautuk_offline_agent/agent.py
+++ b/src/kautuk_offline_agent/agent.py
@@ -70,6 +70,7 @@ class OfflineCodingAgent:
         progress_callback: Callable[[str], None] | None = None,
         approve_major_changes: bool = False,
         major_change_threshold: int = 10,
+        apply_changes_callback: Callable[[list[dict]], bool] | None = None,
     ) -> dict:
         workspace = workspace.resolve()
         workspace.mkdir(parents=True, exist_ok=True)
@@ -97,6 +98,7 @@ class OfflineCodingAgent:
             tooling,
             approve_major_changes=approve_major_changes,
             major_change_threshold=major_change_threshold,
+            apply_changes_callback=apply_changes_callback,
         )
         self._emit_progress(progress_callback, "Materialized generated files.")
 
@@ -134,7 +136,11 @@ class OfflineCodingAgent:
                 f"Command: {failed.command}\nOutput:\n{failed.merged_output}",
             )
             memory.conversation_history.append(fix_reflection)
-            current_output, debug_changes = self._materialize(debug_response, tooling)
+            current_output, debug_changes = self._materialize(
+                debug_response,
+                tooling,
+                apply_changes_callback=apply_changes_callback,
+            )
             file_changes.extend(debug_changes)
             self._emit_progress(progress_callback, f"Iteration {idx} failed; applied automated debug fix.")
 
@@ -240,6 +246,7 @@ class OfflineCodingAgent:
         tooling: LocalTooling,
         approve_major_changes: bool = True,
         major_change_threshold: int = 10,
+        apply_changes_callback: Callable[[list[dict]], bool] | None = None,
     ) -> tuple[StructuredOutput, list[FileChange]]:
         parsed = parse_structured_output(raw)
         if not parsed.files:
@@ -249,6 +256,7 @@ class OfflineCodingAgent:
                 f"Major change detected ({len(parsed.files)} files). "
                 "Set approve_major_changes=True to continue."
             )
+        pending_changes: list[tuple[str, str, str]] = []
         changes: list[FileChange] = []
         for generated in parsed.files:
             try:
@@ -257,7 +265,6 @@ class OfflineCodingAgent:
             except FileNotFoundError:
                 existing = ""
                 status = "created"
-            tooling.write_file(generated.path, generated.content)
             diff_lines = list(
                 unified_diff(
                     existing.splitlines(),
@@ -270,6 +277,15 @@ class OfflineCodingAgent:
             )
             preview = "\n".join(diff_lines[:40])
             changes.append(FileChange(path=generated.path, status=status, diff_preview=preview))
+            pending_changes.append((generated.path, generated.content, status))
+
+        if apply_changes_callback is not None:
+            approved = apply_changes_callback([change.__dict__ for change in changes])
+            if not approved:
+                raise ValueError("User declined applying proposed file changes.")
+
+        for path, content, _status in pending_changes:
+            tooling.write_file(path, content)
         return parsed, changes
 
     def _reflect(self, models: ModelSelection, content: str) -> str:

--- a/src/kautuk_offline_agent/agent.py
+++ b/src/kautuk_offline_agent/agent.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable
 
 from .memory import SessionMemory
 from .models import ModelSelection, select_models
@@ -55,6 +56,7 @@ class OfflineCodingAgent:
         workspace: Path,
         max_iters: int = 5,
         memory_file: Path | None = None,
+        progress_callback: Callable[[str], None] | None = None,
     ) -> dict:
         workspace = workspace.resolve()
         workspace.mkdir(parents=True, exist_ok=True)
@@ -66,11 +68,17 @@ class OfflineCodingAgent:
         memory.compact()
 
         models = select_models(task)
-        codebase_snapshot = self._describe_codebase(tooling.list_files("."))
+        all_files = tooling.list_files(".")
+        relevant_files = self._select_relevant_files(task, all_files)
+        codebase_snapshot = self._describe_codebase(relevant_files)
+        self._emit_progress(progress_callback, "Analyzed codebase and selected relevant files.")
         planner_output = self._plan(task, models, memory)
+        self._emit_progress(progress_callback, "Generated plan.")
         plan_reflection = self._reflect(models, f"Reflect on this plan and improve it:\n\n{planner_output}")
+        self._emit_progress(progress_callback, "Reflected on plan quality.")
         coded = self._code(task, planner_output, models, memory, codebase_snapshot)
         parsed = self._materialize(coded, tooling)
+        self._emit_progress(progress_callback, "Materialized generated files.")
 
         iteration_logs: list[IterationLog] = []
         current_output = parsed
@@ -96,6 +104,7 @@ class OfflineCodingAgent:
                     break
 
             if failed is None:
+                self._emit_progress(progress_callback, f"Iteration {idx} executed successfully.")
                 break
 
             debug_response = self._debug(task, planner_output, models, memory, failed)
@@ -106,8 +115,10 @@ class OfflineCodingAgent:
             )
             memory.conversation_history.append(fix_reflection)
             current_output = self._materialize(debug_response, tooling)
+            self._emit_progress(progress_callback, f"Iteration {idx} failed; applied automated debug fix.")
 
         review_notes = self._review(task, planner_output, models, memory, tooling.list_files("."))
+        self._emit_progress(progress_callback, "Completed review step.")
 
         memory.project_files = tooling.list_files(".")
         memory.save(memory_path)
@@ -120,6 +131,7 @@ class OfflineCodingAgent:
             "codebase_analysis": parsed.codebase_analysis,
             "review_notes": review_notes,
             "written_files": [generated.path for generated in parsed.files],
+            "relevant_files": relevant_files,
             "iterations": iteration_logs,
             "model_iteration_log": parsed.iteration_log,
             "memory_file": str(memory_path),
@@ -218,3 +230,24 @@ class OfflineCodingAgent:
         sample = files[:max_files]
         suffix = "" if len(files) <= max_files else f"\n...and {len(files) - max_files} more files."
         return "\n".join(sample) + suffix
+
+    @staticmethod
+    def _select_relevant_files(task: str, files: list[str], max_files: int = 25) -> list[str]:
+        if not files:
+            return []
+        keywords = {token for token in task.lower().split() if len(token) > 3}
+        scored: list[tuple[int, str]] = []
+        for path in files:
+            lower_path = path.lower()
+            score = sum(1 for keyword in keywords if keyword in lower_path)
+            scored.append((score, path))
+        scored.sort(key=lambda item: (item[0], item[1]), reverse=True)
+        selected = [path for score, path in scored if score > 0][:max_files]
+        if selected:
+            return selected
+        return files[:max_files]
+
+    @staticmethod
+    def _emit_progress(progress_callback: Callable[[str], None] | None, message: str) -> None:
+        if progress_callback is not None:
+            progress_callback(message)

--- a/src/kautuk_offline_agent/agent.py
+++ b/src/kautuk_offline_agent/agent.py
@@ -55,6 +55,7 @@ class FileChange:
     path: str
     status: str
     diff_preview: str
+    applied: bool
 
 
 class OfflineCodingAgent:
@@ -71,6 +72,7 @@ class OfflineCodingAgent:
         approve_major_changes: bool = False,
         major_change_threshold: int = 10,
         apply_changes_callback: Callable[[list[dict]], bool] | None = None,
+        propose_only: bool = False,
     ) -> dict:
         workspace = workspace.resolve()
         workspace.mkdir(parents=True, exist_ok=True)
@@ -99,6 +101,7 @@ class OfflineCodingAgent:
             approve_major_changes=approve_major_changes,
             major_change_threshold=major_change_threshold,
             apply_changes_callback=apply_changes_callback,
+            apply_writes=not propose_only,
         )
         self._emit_progress(progress_callback, "Materialized generated files.")
 
@@ -140,6 +143,7 @@ class OfflineCodingAgent:
                 debug_response,
                 tooling,
                 apply_changes_callback=apply_changes_callback,
+                apply_writes=not propose_only,
             )
             file_changes.extend(debug_changes)
             self._emit_progress(progress_callback, f"Iteration {idx} failed; applied automated debug fix.")
@@ -161,6 +165,7 @@ class OfflineCodingAgent:
             "review_notes": review_notes,
             "written_files": [generated.path for generated in parsed.files],
             "file_changes": [change.__dict__ for change in file_changes],
+            "propose_only": propose_only,
             "relevant_files": relevant_files,
             "iterations": iteration_logs,
             "model_iteration_log": parsed.iteration_log,
@@ -247,6 +252,7 @@ class OfflineCodingAgent:
         approve_major_changes: bool = True,
         major_change_threshold: int = 10,
         apply_changes_callback: Callable[[list[dict]], bool] | None = None,
+        apply_writes: bool = True,
     ) -> tuple[StructuredOutput, list[FileChange]]:
         parsed = parse_structured_output(raw)
         if not parsed.files:
@@ -276,7 +282,7 @@ class OfflineCodingAgent:
                 )
             )
             preview = "\n".join(diff_lines[:40])
-            changes.append(FileChange(path=generated.path, status=status, diff_preview=preview))
+            changes.append(FileChange(path=generated.path, status=status, diff_preview=preview, applied=False))
             pending_changes.append((generated.path, generated.content, status))
 
         if apply_changes_callback is not None:
@@ -284,8 +290,16 @@ class OfflineCodingAgent:
             if not approved:
                 raise ValueError("User declined applying proposed file changes.")
 
-        for path, content, _status in pending_changes:
-            tooling.write_file(path, content)
+        if apply_writes:
+            for path, content, _status in pending_changes:
+                tooling.write_file(path, content)
+            for idx, change in enumerate(changes):
+                changes[idx] = FileChange(
+                    path=change.path,
+                    status=change.status,
+                    diff_preview=change.diff_preview,
+                    applied=True,
+                )
         return parsed, changes
 
     def _reflect(self, models: ModelSelection, content: str) -> str:

--- a/src/kautuk_offline_agent/cli.py
+++ b/src/kautuk_offline_agent/cli.py
@@ -12,6 +12,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("task", help="Natural language coding request.")
     parser.add_argument("--workspace", default="generated_project", help="Directory to generate code into.")
     parser.add_argument("--memory-file", default=None, help="Optional path for persistent memory JSON.")
+    parser.add_argument("--stream", action="store_true", help="Print incremental progress updates.")
     parser.add_argument(
         "--max-iters",
         type=int,
@@ -30,6 +31,7 @@ def main() -> None:
         workspace=Path(args.workspace),
         max_iters=max(1, min(args.max_iters, 5)),
         memory_file=Path(args.memory_file) if args.memory_file else None,
+        progress_callback=(lambda msg: print(f"[progress] {msg}")) if args.stream else None,
     )
 
     serializable = {
@@ -40,6 +42,7 @@ def main() -> None:
         "codebase_analysis": result["codebase_analysis"],
         "review_notes": result["review_notes"],
         "written_files": result["written_files"],
+        "relevant_files": result["relevant_files"],
         "iterations": [entry.__dict__ for entry in result["iterations"]],
         "model_iteration_log": result["model_iteration_log"],
         "memory_file": result["memory_file"],

--- a/src/kautuk_offline_agent/cli.py
+++ b/src/kautuk_offline_agent/cli.py
@@ -41,6 +41,7 @@ def main() -> None:
         progress_callback=(lambda msg: print(f"[progress] {msg}")) if args.stream else None,
         approve_major_changes=(not args.interactive) or _confirm_major_changes(),
         major_change_threshold=max(1, args.major_change_threshold),
+        apply_changes_callback=_interactive_change_review if args.interactive else None,
     )
 
     serializable = {
@@ -64,6 +65,16 @@ def main() -> None:
 
 def _confirm_major_changes() -> bool:
     answer = input("Major changes may be required. Continue? [y/N]: ").strip().lower()
+    return answer in {"y", "yes"}
+
+
+def _interactive_change_review(changes: list[dict]) -> bool:
+    print("\n[diff preview]")
+    for change in changes:
+        print(f"- {change['status']}: {change['path']}")
+        if change["diff_preview"]:
+            print(change["diff_preview"])
+    answer = input("Apply these changes? [y/N]: ").strip().lower()
     return answer in {"y", "yes"}
 
 

--- a/src/kautuk_offline_agent/cli.py
+++ b/src/kautuk_offline_agent/cli.py
@@ -10,25 +10,35 @@ from .agent import OfflineCodingAgent
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Offline autonomous coding assistant using Ollama.")
     parser.add_argument("task", help="Natural language coding request.")
+    parser.add_argument("--workspace", default="generated_project", help="Directory to generate code into.")
+    parser.add_argument("--memory-file", default=None, help="Optional path for persistent memory JSON.")
     parser.add_argument(
-        "--workspace",
-        default="generated_project",
-        help="Workspace directory where files will be generated.",
+        "--max-iters",
+        type=int,
+        default=5,
+        help="Maximum debug iterations (execution loop).",
     )
-    parser.add_argument("--max-iters", type=int, default=3, help="Maximum auto-fix attempts.")
     return parser
 
 
 def main() -> None:
     args = build_parser().parse_args()
     agent = OfflineCodingAgent()
-    result = agent.run(task=args.task, workspace=Path(args.workspace), max_iters=args.max_iters)
+
+    result = agent.run(
+        task=args.task,
+        workspace=Path(args.workspace),
+        max_iters=max(1, min(args.max_iters, 5)),
+        memory_file=Path(args.memory_file) if args.memory_file else None,
+    )
 
     serializable = {
         "models": result["models"].__dict__,
-        "plan": result["plan"],
+        "planner_output": result["planner_output"],
+        "review_notes": result["review_notes"],
         "written_files": result["written_files"],
-        "run_results": [r.__dict__ for r in result["run_results"]],
+        "iterations": [entry.__dict__ for entry in result["iterations"]],
+        "memory_file": result["memory_file"],
     }
     print(json.dumps(serializable, indent=2))
 

--- a/src/kautuk_offline_agent/cli.py
+++ b/src/kautuk_offline_agent/cli.py
@@ -36,6 +36,8 @@ def main() -> None:
 
     serializable = {
         "models": result["models"].__dict__,
+        "technical_spec": result["technical_spec"],
+        "model_spec": result["model_spec"],
         "planner_output": result["planner_output"],
         "plan_reflection": result["plan_reflection"],
         "generation_reflection": result["generation_reflection"],

--- a/src/kautuk_offline_agent/cli.py
+++ b/src/kautuk_offline_agent/cli.py
@@ -14,6 +14,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--memory-file", default=None, help="Optional path for persistent memory JSON.")
     parser.add_argument("--stream", action="store_true", help="Print incremental progress updates.")
     parser.add_argument("--interactive", action="store_true", help="Prompt before applying major file batches.")
+    parser.add_argument("--propose-only", action="store_true", help="Preview and validate changes without writing files.")
     parser.add_argument(
         "--major-change-threshold",
         type=int,
@@ -42,6 +43,7 @@ def main() -> None:
         approve_major_changes=(not args.interactive) or _confirm_major_changes(),
         major_change_threshold=max(1, args.major_change_threshold),
         apply_changes_callback=_interactive_change_review if args.interactive else None,
+        propose_only=args.propose_only,
     )
 
     serializable = {
@@ -55,6 +57,7 @@ def main() -> None:
         "review_notes": result["review_notes"],
         "written_files": result["written_files"],
         "file_changes": result["file_changes"],
+        "propose_only": result["propose_only"],
         "relevant_files": result["relevant_files"],
         "iterations": [entry.__dict__ for entry in result["iterations"]],
         "model_iteration_log": result["model_iteration_log"],

--- a/src/kautuk_offline_agent/cli.py
+++ b/src/kautuk_offline_agent/cli.py
@@ -13,6 +13,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--workspace", default="generated_project", help="Directory to generate code into.")
     parser.add_argument("--memory-file", default=None, help="Optional path for persistent memory JSON.")
     parser.add_argument("--stream", action="store_true", help="Print incremental progress updates.")
+    parser.add_argument("--interactive", action="store_true", help="Prompt before applying major file batches.")
+    parser.add_argument(
+        "--major-change-threshold",
+        type=int,
+        default=10,
+        help="Number of changed files considered a major change.",
+    )
     parser.add_argument(
         "--max-iters",
         type=int,
@@ -32,6 +39,8 @@ def main() -> None:
         max_iters=max(1, min(args.max_iters, 5)),
         memory_file=Path(args.memory_file) if args.memory_file else None,
         progress_callback=(lambda msg: print(f"[progress] {msg}")) if args.stream else None,
+        approve_major_changes=(not args.interactive) or _confirm_major_changes(),
+        major_change_threshold=max(1, args.major_change_threshold),
     )
 
     serializable = {
@@ -44,12 +53,18 @@ def main() -> None:
         "codebase_analysis": result["codebase_analysis"],
         "review_notes": result["review_notes"],
         "written_files": result["written_files"],
+        "file_changes": result["file_changes"],
         "relevant_files": result["relevant_files"],
         "iterations": [entry.__dict__ for entry in result["iterations"]],
         "model_iteration_log": result["model_iteration_log"],
         "memory_file": result["memory_file"],
     }
     print(json.dumps(serializable, indent=2))
+
+
+def _confirm_major_changes() -> bool:
+    answer = input("Major changes may be required. Continue? [y/N]: ").strip().lower()
+    return answer in {"y", "yes"}
 
 
 if __name__ == "__main__":

--- a/src/kautuk_offline_agent/cli.py
+++ b/src/kautuk_offline_agent/cli.py
@@ -37,6 +37,7 @@ def main() -> None:
         "planner_output": result["planner_output"],
         "plan_reflection": result["plan_reflection"],
         "generation_reflection": result["generation_reflection"],
+        "codebase_analysis": result["codebase_analysis"],
         "review_notes": result["review_notes"],
         "written_files": result["written_files"],
         "iterations": [entry.__dict__ for entry in result["iterations"]],

--- a/src/kautuk_offline_agent/cli.py
+++ b/src/kautuk_offline_agent/cli.py
@@ -35,9 +35,12 @@ def main() -> None:
     serializable = {
         "models": result["models"].__dict__,
         "planner_output": result["planner_output"],
+        "plan_reflection": result["plan_reflection"],
+        "generation_reflection": result["generation_reflection"],
         "review_notes": result["review_notes"],
         "written_files": result["written_files"],
         "iterations": [entry.__dict__ for entry in result["iterations"]],
+        "model_iteration_log": result["model_iteration_log"],
         "memory_file": result["memory_file"],
     }
     print(json.dumps(serializable, indent=2))

--- a/src/kautuk_offline_agent/cli.py
+++ b/src/kautuk_offline_agent/cli.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .agent import OfflineCodingAgent
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Offline autonomous coding assistant using Ollama.")
+    parser.add_argument("task", help="Natural language coding request.")
+    parser.add_argument(
+        "--workspace",
+        default="generated_project",
+        help="Workspace directory where files will be generated.",
+    )
+    parser.add_argument("--max-iters", type=int, default=3, help="Maximum auto-fix attempts.")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    agent = OfflineCodingAgent()
+    result = agent.run(task=args.task, workspace=Path(args.workspace), max_iters=args.max_iters)
+
+    serializable = {
+        "models": result["models"].__dict__,
+        "plan": result["plan"],
+        "written_files": result["written_files"],
+        "run_results": [r.__dict__ for r in result["run_results"]],
+    }
+    print(json.dumps(serializable, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kautuk_offline_agent/memory.py
+++ b/src/kautuk_offline_agent/memory.py
@@ -8,6 +8,7 @@ from pathlib import Path
 @dataclass
 class SessionMemory:
     conversation_history: list[str] = field(default_factory=list)
+    conversation_summary: str = ""
     project_files: list[str] = field(default_factory=list)
     previous_errors: list[str] = field(default_factory=list)
 
@@ -18,6 +19,7 @@ class SessionMemory:
         data = json.loads(path.read_text(encoding="utf-8"))
         return cls(
             conversation_history=list(data.get("conversation_history", [])),
+            conversation_summary=str(data.get("conversation_summary", "")),
             project_files=list(data.get("project_files", [])),
             previous_errors=list(data.get("previous_errors", [])),
         )
@@ -25,3 +27,11 @@ class SessionMemory:
     def save(self, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(asdict(self), indent=2), encoding="utf-8")
+
+    def compact(self, max_items: int = 20) -> None:
+        if len(self.conversation_history) <= max_items:
+            return
+        older = self.conversation_history[:-max_items]
+        if older:
+            self.conversation_summary = f"{self.conversation_summary} {' | '.join(older)}".strip()
+        self.conversation_history = self.conversation_history[-max_items:]

--- a/src/kautuk_offline_agent/memory.py
+++ b/src/kautuk_offline_agent/memory.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class SessionMemory:
+    conversation_history: list[str] = field(default_factory=list)
+    project_files: list[str] = field(default_factory=list)
+    previous_errors: list[str] = field(default_factory=list)
+
+    @classmethod
+    def load(cls, path: Path) -> "SessionMemory":
+        if not path.exists():
+            return cls()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return cls(
+            conversation_history=list(data.get("conversation_history", [])),
+            project_files=list(data.get("project_files", [])),
+            previous_errors=list(data.get("previous_errors", [])),
+        )
+
+    def save(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(asdict(self), indent=2), encoding="utf-8")

--- a/src/kautuk_offline_agent/models.py
+++ b/src/kautuk_offline_agent/models.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelSelection:
+    planner: str
+    coder: str
+    chat: str
+
+
+def select_models(task: str) -> ModelSelection:
+    """Choose local models for planning/coding/chat based on task complexity."""
+    task_lower = task.lower()
+    simple = len(task.split()) < 12 and not any(
+        keyword in task_lower
+        for keyword in ("build", "create", "app", "script", "api", "debug", "refactor")
+    )
+
+    if simple:
+        return ModelSelection(planner="llama3", coder="deepseek-coder", chat="gemma:2b")
+
+    return ModelSelection(planner="mistral", coder="deepseek-coder", chat="gemma:2b")

--- a/src/kautuk_offline_agent/ollama_client.py
+++ b/src/kautuk_offline_agent/ollama_client.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+
+class OllamaError(RuntimeError):
+    """Raised when an Ollama call fails."""
+
+
+@dataclass
+class OllamaClient:
+    base_url: str = "http://localhost:11434"
+    timeout_seconds: int = 300
+
+    def generate(self, model: str, prompt: str, system: str | None = None) -> str:
+        payload = {
+            "model": model,
+            "prompt": prompt,
+            "stream": False,
+            "options": {"temperature": 0.2},
+        }
+        if system:
+            payload["system"] = system
+
+        req = urllib.request.Request(
+            f"{self.base_url}/api/generate",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout_seconds) as response:
+                body = json.loads(response.read().decode("utf-8"))
+        except urllib.error.URLError as exc:
+            raise OllamaError(
+                "Could not reach Ollama. Ensure `ollama serve` is running on localhost:11434."
+            ) from exc
+        except json.JSONDecodeError as exc:
+            raise OllamaError("Ollama returned invalid JSON.") from exc
+
+        text = body.get("response", "").strip()
+        if not text:
+            raise OllamaError("Ollama returned an empty response.")
+        return text

--- a/src/kautuk_offline_agent/tools.py
+++ b/src/kautuk_offline_agent/tools.py
@@ -11,6 +11,7 @@ class CommandResult:
     returncode: int
     stdout: str
     stderr: str
+    timed_out: bool = False
 
     @property
     def ok(self) -> bool:
@@ -52,20 +53,30 @@ class LocalTooling:
             if path.is_file()
         )
 
-    def run_command(self, command: str) -> CommandResult:
-        completed = subprocess.run(
-            command,
-            cwd=self.workspace,
-            shell=True,
-            capture_output=True,
-            text=True,
-        )
-        return CommandResult(
-            command=command,
-            returncode=completed.returncode,
-            stdout=completed.stdout,
-            stderr=completed.stderr,
-        )
+    def run_command(self, command: str, timeout_seconds: int = 120) -> CommandResult:
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=self.workspace,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+            )
+            return CommandResult(
+                command=command,
+                returncode=completed.returncode,
+                stdout=completed.stdout,
+                stderr=completed.stderr,
+            )
+        except subprocess.TimeoutExpired as exc:
+            return CommandResult(
+                command=command,
+                returncode=124,
+                stdout=exc.stdout or "",
+                stderr=(exc.stderr or "") + f"\nCommand timed out after {timeout_seconds}s.",
+                timed_out=True,
+            )
 
     def install_package(self, package: str) -> CommandResult:
         return self.run_command(f"python -m pip install {package}")

--- a/src/kautuk_offline_agent/tools.py
+++ b/src/kautuk_offline_agent/tools.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class CommandResult:
+    command: str
+    returncode: int
+    stdout: str
+    stderr: str
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+    @property
+    def merged_output(self) -> str:
+        return (self.stdout + "\n" + self.stderr).strip()
+
+
+class LocalTooling:
+    """Local toolset used by the agent; mirrors the expected tool contract."""
+
+    def __init__(self, workspace: Path) -> None:
+        self.workspace = workspace.resolve()
+
+    def _safe_path(self, path: str) -> Path:
+        candidate = (self.workspace / path).resolve()
+        if self.workspace not in candidate.parents and candidate != self.workspace:
+            raise ValueError(f"Path escapes workspace: {path}")
+        return candidate
+
+    def read_file(self, path: str) -> str:
+        return self._safe_path(path).read_text(encoding="utf-8")
+
+    def write_file(self, path: str, content: str) -> Path:
+        target = self._safe_path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        return target
+
+    def list_files(self, directory: str = ".") -> list[str]:
+        root = self._safe_path(directory)
+        if not root.exists():
+            return []
+        return sorted(
+            str(path.relative_to(self.workspace))
+            for path in root.rglob("*")
+            if path.is_file()
+        )
+
+    def run_command(self, command: str) -> CommandResult:
+        completed = subprocess.run(
+            command,
+            cwd=self.workspace,
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+        return CommandResult(
+            command=command,
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )
+
+    def install_package(self, package: str) -> CommandResult:
+        return self.run_command(f"python -m pip install {package}")

--- a/src/kautuk_offline_agent/tools.py
+++ b/src/kautuk_offline_agent/tools.py
@@ -25,8 +25,9 @@ class CommandResult:
 class LocalTooling:
     """Local toolset used by the agent; mirrors the expected tool contract."""
 
-    def __init__(self, workspace: Path) -> None:
+    def __init__(self, workspace: Path, allow_destructive: bool = False) -> None:
         self.workspace = workspace.resolve()
+        self.allow_destructive = allow_destructive
 
     def _safe_path(self, path: str) -> Path:
         candidate = (self.workspace / path).resolve()
@@ -54,6 +55,13 @@ class LocalTooling:
         )
 
     def run_command(self, command: str, timeout_seconds: int = 120) -> CommandResult:
+        if not self.allow_destructive and self._looks_destructive(command):
+            return CommandResult(
+                command=command,
+                returncode=2,
+                stdout="",
+                stderr="Blocked potentially destructive command. Re-run with allow_destructive=True to override.",
+            )
         try:
             completed = subprocess.run(
                 command,
@@ -80,3 +88,9 @@ class LocalTooling:
 
     def install_package(self, package: str) -> CommandResult:
         return self.run_command(f"python -m pip install {package}")
+
+    @staticmethod
+    def _looks_destructive(command: str) -> bool:
+        risky_tokens = ("rm -rf", "mkfs", "dd if=", ":(){", "shutdown", "reboot")
+        lower_command = command.lower()
+        return any(token in lower_command for token in risky_tokens)

--- a/src/kautuk_offline_agent/workspace.py
+++ b/src/kautuk_offline_agent/workspace.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 PLAN_PATTERN = re.compile(r"<plan>\n(.*?)\n</plan>", re.DOTALL)
 REFLECTION_PATTERN = re.compile(r"<reflection>\n(.*?)\n</reflection>", re.DOTALL)
+CODEBASE_ANALYSIS_PATTERN = re.compile(r"<codebase_analysis>\n(.*?)\n</codebase_analysis>", re.DOTALL)
 FILE_PATTERN = re.compile(r'<file\s+path="([^"]+)">\n(.*?)\n</file>', re.DOTALL)
 COMMANDS_PATTERN = re.compile(r"<commands>\n(.*?)\n</commands>", re.DOTALL)
 ITERATION_LOG_PATTERN = re.compile(r"<iteration_log>\n(.*?)\n</iteration_log>", re.DOTALL)
@@ -21,6 +22,7 @@ class GeneratedFile:
 class StructuredOutput:
     plan: str
     reflection: str
+    codebase_analysis: str
     files: list[GeneratedFile]
     commands: list[str]
     iteration_log: str
@@ -31,6 +33,8 @@ def parse_structured_output(raw: str) -> StructuredOutput:
     plan = plan_match.group(1).strip() if plan_match else ""
     reflection_match = REFLECTION_PATTERN.search(raw)
     reflection = reflection_match.group(1).strip() if reflection_match else ""
+    codebase_analysis_match = CODEBASE_ANALYSIS_PATTERN.search(raw)
+    codebase_analysis = codebase_analysis_match.group(1).strip() if codebase_analysis_match else ""
 
     files = [GeneratedFile(path=path, content=content.rstrip("\n") + "\n") for path, content in FILE_PATTERN.findall(raw)]
 
@@ -45,6 +49,7 @@ def parse_structured_output(raw: str) -> StructuredOutput:
     return StructuredOutput(
         plan=plan,
         reflection=reflection,
+        codebase_analysis=codebase_analysis,
         files=files,
         commands=commands,
         iteration_log=iteration_log,

--- a/src/kautuk_offline_agent/workspace.py
+++ b/src/kautuk_offline_agent/workspace.py
@@ -5,8 +5,10 @@ from dataclasses import dataclass
 
 
 PLAN_PATTERN = re.compile(r"<plan>\n(.*?)\n</plan>", re.DOTALL)
+REFLECTION_PATTERN = re.compile(r"<reflection>\n(.*?)\n</reflection>", re.DOTALL)
 FILE_PATTERN = re.compile(r'<file\s+path="([^"]+)">\n(.*?)\n</file>', re.DOTALL)
 COMMANDS_PATTERN = re.compile(r"<commands>\n(.*?)\n</commands>", re.DOTALL)
+ITERATION_LOG_PATTERN = re.compile(r"<iteration_log>\n(.*?)\n</iteration_log>", re.DOTALL)
 
 
 @dataclass
@@ -18,13 +20,17 @@ class GeneratedFile:
 @dataclass
 class StructuredOutput:
     plan: str
+    reflection: str
     files: list[GeneratedFile]
     commands: list[str]
+    iteration_log: str
 
 
 def parse_structured_output(raw: str) -> StructuredOutput:
     plan_match = PLAN_PATTERN.search(raw)
     plan = plan_match.group(1).strip() if plan_match else ""
+    reflection_match = REFLECTION_PATTERN.search(raw)
+    reflection = reflection_match.group(1).strip() if reflection_match else ""
 
     files = [GeneratedFile(path=path, content=content.rstrip("\n") + "\n") for path, content in FILE_PATTERN.findall(raw)]
 
@@ -33,4 +39,13 @@ def parse_structured_output(raw: str) -> StructuredOutput:
     if commands_match:
         commands = [line.strip() for line in commands_match.group(1).splitlines() if line.strip()]
 
-    return StructuredOutput(plan=plan, files=files, commands=commands)
+    iteration_log_match = ITERATION_LOG_PATTERN.search(raw)
+    iteration_log = iteration_log_match.group(1).strip() if iteration_log_match else ""
+
+    return StructuredOutput(
+        plan=plan,
+        reflection=reflection,
+        files=files,
+        commands=commands,
+        iteration_log=iteration_log,
+    )

--- a/src/kautuk_offline_agent/workspace.py
+++ b/src/kautuk_offline_agent/workspace.py
@@ -4,6 +4,7 @@ import re
 from dataclasses import dataclass
 
 
+SPEC_PATTERN = re.compile(r"<spec>\n(.*?)\n</spec>", re.DOTALL)
 PLAN_PATTERN = re.compile(r"<plan>\n(.*?)\n</plan>", re.DOTALL)
 REFLECTION_PATTERN = re.compile(r"<reflection>\n(.*?)\n</reflection>", re.DOTALL)
 CODEBASE_ANALYSIS_PATTERN = re.compile(r"<codebase_analysis>\n(.*?)\n</codebase_analysis>", re.DOTALL)
@@ -20,6 +21,7 @@ class GeneratedFile:
 
 @dataclass
 class StructuredOutput:
+    spec: str
     plan: str
     reflection: str
     codebase_analysis: str
@@ -29,6 +31,8 @@ class StructuredOutput:
 
 
 def parse_structured_output(raw: str) -> StructuredOutput:
+    spec_match = SPEC_PATTERN.search(raw)
+    spec = spec_match.group(1).strip() if spec_match else ""
     plan_match = PLAN_PATTERN.search(raw)
     plan = plan_match.group(1).strip() if plan_match else ""
     reflection_match = REFLECTION_PATTERN.search(raw)
@@ -47,6 +51,7 @@ def parse_structured_output(raw: str) -> StructuredOutput:
     iteration_log = iteration_log_match.group(1).strip() if iteration_log_match else ""
 
     return StructuredOutput(
+        spec=spec,
         plan=plan,
         reflection=reflection,
         codebase_analysis=codebase_analysis,

--- a/src/kautuk_offline_agent/workspace.py
+++ b/src/kautuk_offline_agent/workspace.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+FILE_PATTERN = re.compile(r'<file\s+path="([^"]+)">\n(.*?)\n</file>', re.DOTALL)
+RUN_PATTERN = re.compile(r"<run>\n(.*?)\n</run>", re.DOTALL)
+
+
+@dataclass
+class GeneratedArtifact:
+    path: Path
+    content: str
+
+
+@dataclass
+class ModelOutput:
+    artifacts: list[GeneratedArtifact]
+    run_commands: list[str]
+
+
+def parse_model_output(raw: str, root: Path) -> ModelOutput:
+    artifacts: list[GeneratedArtifact] = []
+    for relative_path, content in FILE_PATTERN.findall(raw):
+        safe_path = (root / relative_path).resolve()
+        if root.resolve() not in safe_path.parents and safe_path != root.resolve():
+            raise ValueError(f"Blocked path outside workspace: {relative_path}")
+        artifacts.append(GeneratedArtifact(path=safe_path, content=content.rstrip("\n") + "\n"))
+
+    run_commands = [command.strip() for command in RUN_PATTERN.findall(raw) if command.strip()]
+    return ModelOutput(artifacts=artifacts, run_commands=run_commands)
+
+
+def write_artifacts(artifacts: Iterable[GeneratedArtifact]) -> list[Path]:
+    written: list[Path] = []
+    for artifact in artifacts:
+        artifact.path.parent.mkdir(parents=True, exist_ok=True)
+        artifact.path.write_text(artifact.content, encoding="utf-8")
+        written.append(artifact.path)
+    return written

--- a/src/kautuk_offline_agent/workspace.py
+++ b/src/kautuk_offline_agent/workspace.py
@@ -2,42 +2,35 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Iterable
 
 
+PLAN_PATTERN = re.compile(r"<plan>\n(.*?)\n</plan>", re.DOTALL)
 FILE_PATTERN = re.compile(r'<file\s+path="([^"]+)">\n(.*?)\n</file>', re.DOTALL)
-RUN_PATTERN = re.compile(r"<run>\n(.*?)\n</run>", re.DOTALL)
+COMMANDS_PATTERN = re.compile(r"<commands>\n(.*?)\n</commands>", re.DOTALL)
 
 
 @dataclass
-class GeneratedArtifact:
-    path: Path
+class GeneratedFile:
+    path: str
     content: str
 
 
 @dataclass
-class ModelOutput:
-    artifacts: list[GeneratedArtifact]
-    run_commands: list[str]
+class StructuredOutput:
+    plan: str
+    files: list[GeneratedFile]
+    commands: list[str]
 
 
-def parse_model_output(raw: str, root: Path) -> ModelOutput:
-    artifacts: list[GeneratedArtifact] = []
-    for relative_path, content in FILE_PATTERN.findall(raw):
-        safe_path = (root / relative_path).resolve()
-        if root.resolve() not in safe_path.parents and safe_path != root.resolve():
-            raise ValueError(f"Blocked path outside workspace: {relative_path}")
-        artifacts.append(GeneratedArtifact(path=safe_path, content=content.rstrip("\n") + "\n"))
+def parse_structured_output(raw: str) -> StructuredOutput:
+    plan_match = PLAN_PATTERN.search(raw)
+    plan = plan_match.group(1).strip() if plan_match else ""
 
-    run_commands = [command.strip() for command in RUN_PATTERN.findall(raw) if command.strip()]
-    return ModelOutput(artifacts=artifacts, run_commands=run_commands)
+    files = [GeneratedFile(path=path, content=content.rstrip("\n") + "\n") for path, content in FILE_PATTERN.findall(raw)]
 
+    commands_match = COMMANDS_PATTERN.search(raw)
+    commands: list[str] = []
+    if commands_match:
+        commands = [line.strip() for line in commands_match.group(1).splitlines() if line.strip()]
 
-def write_artifacts(artifacts: Iterable[GeneratedArtifact]) -> list[Path]:
-    written: list[Path] = []
-    for artifact in artifacts:
-        artifact.path.parent.mkdir(parents=True, exist_ok=True)
-        artifact.path.write_text(artifact.content, encoding="utf-8")
-        written.append(artifact.path)
-    return written
+    return StructuredOutput(plan=plan, files=files, commands=commands)

--- a/tests/test_agent_utils.py
+++ b/tests/test_agent_utils.py
@@ -24,3 +24,8 @@ class AgentUtilityTests(unittest.TestCase):
         memory.compact(max_items=10)
         self.assertEqual(len(memory.conversation_history), 10)
         self.assertIn("item-0", memory.conversation_summary)
+
+    def test_select_relevant_files(self) -> None:
+        files = ["src/api/server.py", "src/ui/view.py", "README.md"]
+        selected = OfflineCodingAgent._select_relevant_files("update api server routes", files)
+        self.assertIn("src/api/server.py", selected)

--- a/tests/test_agent_utils.py
+++ b/tests/test_agent_utils.py
@@ -1,6 +1,7 @@
 import unittest
 
 from kautuk_offline_agent.agent import OfflineCodingAgent
+from kautuk_offline_agent.memory import SessionMemory
 
 
 class AgentUtilityTests(unittest.TestCase):
@@ -12,3 +13,14 @@ class AgentUtilityTests(unittest.TestCase):
         )
         self.assertEqual(OfflineCodingAgent._classify_error("Traceback (most recent call last):"), "runtime")
         self.assertEqual(OfflineCodingAgent._classify_error("unexpected behavior without traceback"), "logic")
+
+    def test_describe_codebase(self) -> None:
+        description = OfflineCodingAgent._describe_codebase(["a.py", "b.py"])
+        self.assertIn("a.py", description)
+        self.assertIn("b.py", description)
+
+    def test_memory_compact(self) -> None:
+        memory = SessionMemory(conversation_history=[f"item-{i}" for i in range(30)])
+        memory.compact(max_items=10)
+        self.assertEqual(len(memory.conversation_history), 10)
+        self.assertIn("item-0", memory.conversation_summary)

--- a/tests/test_agent_utils.py
+++ b/tests/test_agent_utils.py
@@ -1,0 +1,14 @@
+import unittest
+
+from kautuk_offline_agent.agent import OfflineCodingAgent
+
+
+class AgentUtilityTests(unittest.TestCase):
+    def test_classify_error(self) -> None:
+        self.assertEqual(OfflineCodingAgent._classify_error("SyntaxError: invalid syntax"), "syntax")
+        self.assertEqual(
+            OfflineCodingAgent._classify_error("ModuleNotFoundError: No module named 'x'"),
+            "dependency",
+        )
+        self.assertEqual(OfflineCodingAgent._classify_error("Traceback (most recent call last):"), "runtime")
+        self.assertEqual(OfflineCodingAgent._classify_error("unexpected behavior without traceback"), "logic")

--- a/tests/test_agent_utils.py
+++ b/tests/test_agent_utils.py
@@ -63,3 +63,11 @@ class AgentUtilityTests(unittest.TestCase):
                     tooling,
                     apply_changes_callback=lambda _changes: False,
                 )
+
+    def test_materialize_propose_only_does_not_write_files(self) -> None:
+        raw = """<spec>\ns\n</spec>\n<plan>\np\n</plan>\n<reflection>\nr\n</reflection>\n<codebase_analysis>\nc\n</codebase_analysis>\n<files>\n<file path=\"a.py\">\n1\n</file>\n</files>\n<commands>\npython a.py\n</commands>\n<iteration_log>\nlog\n</iteration_log>"""
+        with TemporaryDirectory() as tmp:
+            tooling = LocalTooling(Path(tmp))
+            _parsed, changes = OfflineCodingAgent._materialize(raw, tooling, apply_writes=False)
+            self.assertFalse((Path(tmp) / "a.py").exists())
+            self.assertFalse(changes[0].applied)

--- a/tests/test_agent_utils.py
+++ b/tests/test_agent_utils.py
@@ -1,7 +1,10 @@
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from kautuk_offline_agent.agent import OfflineCodingAgent
 from kautuk_offline_agent.memory import SessionMemory
+from kautuk_offline_agent.tools import LocalTooling
 
 
 class AgentUtilityTests(unittest.TestCase):
@@ -29,3 +32,23 @@ class AgentUtilityTests(unittest.TestCase):
         files = ["src/api/server.py", "src/ui/view.py", "README.md"]
         selected = OfflineCodingAgent._select_relevant_files("update api server routes", files)
         self.assertIn("src/api/server.py", selected)
+
+    def test_materialize_produces_change_preview(self) -> None:
+        raw = """<spec>\ns\n</spec>\n<plan>\np\n</plan>\n<reflection>\nr\n</reflection>\n<codebase_analysis>\nc\n</codebase_analysis>\n<files>\n<file path=\"a.py\">\nprint('x')\n</file>\n</files>\n<commands>\npython a.py\n</commands>\n<iteration_log>\nlog\n</iteration_log>"""
+        with TemporaryDirectory() as tmp:
+            tooling = LocalTooling(Path(tmp))
+            _, changes = OfflineCodingAgent._materialize(raw, tooling, approve_major_changes=True)
+            self.assertEqual(changes[0].status, "created")
+            self.assertIn("a/a.py", changes[0].diff_preview)
+
+    def test_materialize_blocks_major_changes_without_approval(self) -> None:
+        raw = """<spec>\ns\n</spec>\n<plan>\np\n</plan>\n<reflection>\nr\n</reflection>\n<codebase_analysis>\nc\n</codebase_analysis>\n<files>\n<file path=\"a.py\">\n1\n</file>\n<file path=\"b.py\">\n2\n</file>\n</files>\n<commands>\npython a.py\n</commands>\n<iteration_log>\nlog\n</iteration_log>"""
+        with TemporaryDirectory() as tmp:
+            tooling = LocalTooling(Path(tmp))
+            with self.assertRaises(ValueError):
+                OfflineCodingAgent._materialize(
+                    raw,
+                    tooling,
+                    approve_major_changes=False,
+                    major_change_threshold=1,
+                )

--- a/tests/test_agent_utils.py
+++ b/tests/test_agent_utils.py
@@ -52,3 +52,14 @@ class AgentUtilityTests(unittest.TestCase):
                     approve_major_changes=False,
                     major_change_threshold=1,
                 )
+
+    def test_materialize_honors_apply_callback_decline(self) -> None:
+        raw = """<spec>\ns\n</spec>\n<plan>\np\n</plan>\n<reflection>\nr\n</reflection>\n<codebase_analysis>\nc\n</codebase_analysis>\n<files>\n<file path=\"a.py\">\n1\n</file>\n</files>\n<commands>\npython a.py\n</commands>\n<iteration_log>\nlog\n</iteration_log>"""
+        with TemporaryDirectory() as tmp:
+            tooling = LocalTooling(Path(tmp))
+            with self.assertRaises(ValueError):
+                OfflineCodingAgent._materialize(
+                    raw,
+                    tooling,
+                    apply_changes_callback=lambda _changes: False,
+                )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,14 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from kautuk_offline_agent.tools import LocalTooling
+
+
+class ToolingTests(unittest.TestCase):
+    def test_run_command_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tooling = LocalTooling(Path(tmp))
+            result = tooling.run_command("python -c \"import time; time.sleep(2)\"", timeout_seconds=1)
+            self.assertTrue(result.timed_out)
+            self.assertEqual(result.returncode, 124)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -12,3 +12,10 @@ class ToolingTests(unittest.TestCase):
             result = tooling.run_command("python -c \"import time; time.sleep(2)\"", timeout_seconds=1)
             self.assertTrue(result.timed_out)
             self.assertEqual(result.returncode, 124)
+
+    def test_blocks_destructive_command_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tooling = LocalTooling(Path(tmp))
+            result = tooling.run_command("rm -rf /tmp/something")
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("Blocked potentially destructive command", result.stderr)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5,7 +5,10 @@ from kautuk_offline_agent.workspace import parse_structured_output
 
 class WorkspaceParserTests(unittest.TestCase):
     def test_parse_structured_output_full_blocks(self) -> None:
-        raw = """<plan>
+        raw = """<spec>
+requirement list
+</spec>
+<plan>
 step 1
 </plan>
 <reflection>
@@ -27,6 +30,7 @@ first pass
 </iteration_log>"""
 
         parsed = parse_structured_output(raw)
+        self.assertEqual(parsed.spec, "requirement list")
         self.assertEqual(parsed.plan, "step 1")
         self.assertEqual(parsed.reflection, "looks good")
         self.assertEqual(parsed.codebase_analysis, "has app.py")

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -11,6 +11,9 @@ step 1
 <reflection>
 looks good
 </reflection>
+<codebase_analysis>
+has app.py
+</codebase_analysis>
 <files>
 <file path=\"app.py\">
 print('hi')
@@ -26,6 +29,7 @@ first pass
         parsed = parse_structured_output(raw)
         self.assertEqual(parsed.plan, "step 1")
         self.assertEqual(parsed.reflection, "looks good")
+        self.assertEqual(parsed.codebase_analysis, "has app.py")
         self.assertEqual(parsed.files[0].path, "app.py")
         self.assertEqual(parsed.commands, ["python app.py"])
         self.assertEqual(parsed.iteration_log, "first pass")

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,31 @@
+import unittest
+
+from kautuk_offline_agent.workspace import parse_structured_output
+
+
+class WorkspaceParserTests(unittest.TestCase):
+    def test_parse_structured_output_full_blocks(self) -> None:
+        raw = """<plan>
+step 1
+</plan>
+<reflection>
+looks good
+</reflection>
+<files>
+<file path=\"app.py\">
+print('hi')
+</file>
+</files>
+<commands>
+python app.py
+</commands>
+<iteration_log>
+first pass
+</iteration_log>"""
+
+        parsed = parse_structured_output(raw)
+        self.assertEqual(parsed.plan, "step 1")
+        self.assertEqual(parsed.reflection, "looks good")
+        self.assertEqual(parsed.files[0].path, "app.py")
+        self.assertEqual(parsed.commands, ["python app.py"])
+        self.assertEqual(parsed.iteration_log, "first pass")


### PR DESCRIPTION
### Motivation
- Provide a local-first autonomous coding assistant that uses local Ollama models to plan, generate full project files, execute suggested commands, and attempt automatic fixes when runs fail.
- Enable a deterministic output contract from the code-generation model so generated files and run commands can be safely parsed and materialized into a workspace.
- Offer a simple CLI entrypoint to invoke the agent on natural-language coding requests and return a JSON summary of results.

### Description
- Add a new Python package `kautuk_offline_agent` with core modules: `agent.py` (orchestration and run/fix loop), `ollama_client.py` (Ollama HTTP client with clear errors), `models.py` (model-selection logic), and `workspace.py` (XML-like `<file>`/`<run>` parser and safe writer). 
- Implement a CLI in `cli.py` exposing `kautuk-agent` which accepts a `task`, `--workspace`, and `--max-iters` and prints a JSON summary containing selected models, plan, generated files, and run results.
- Add packaging metadata in `pyproject.toml`, a project `README.md` documenting usage and model strategy, and a `.gitignore` to ignore Python cache artifacts.
- Enforce workspace safety when writing files and provide explicit system prompts for planner/coder/fixer behavior, plus model selection heuristics mapping to `deepseek-coder`, `mistral`/`llama3`, and `gemma:2b`.

### Testing
- Ran Python syntax checks with `python -m py_compile src/kautuk_offline_agent/*.py`, which succeeded.
- Verified the CLI help output with `PYTHONPATH=src python -m kautuk_offline_agent.cli --help`, which succeeded and displayed expected options.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6d0339e88333b9de7610eeb2cbc2)